### PR TITLE
Fix - orchestrator startup failed as Account Interface is not registered

### DIFF
--- a/orchestrator/cosmos/client/context.go
+++ b/orchestrator/cosmos/client/context.go
@@ -17,6 +17,7 @@ import (
 	keyscodec "github.com/InjectiveLabs/sdk-go/chain/crypto/codec"
 
 	peggy "github.com/InjectiveLabs/peggo/modules/peggy/types"
+	ctypes "github.com/InjectiveLabs/sdk-go/chain/types"
 )
 
 // NewTxConfig initializes new Cosmos TxConfig with certain signModes enabled.
@@ -27,6 +28,7 @@ func NewTxConfig(signModes []signingtypes.SignMode) client.TxConfig {
 
 	// This is specific to Injective chain (\w Ethermint keys)
 	keyscodec.RegisterInterfaces(interfaceRegistry)
+	ctypes.RegisterInterfaces(interfaceRegistry)
 
 	marshaler := codec.NewProtoCodec(interfaceRegistry)
 	return tx.NewTxConfig(marshaler, signModes)
@@ -46,6 +48,7 @@ func NewClientContext(
 
 	// This is specific to Injective chain (\w Ethermint keys)
 	keyscodec.RegisterInterfaces(interfaceRegistry)
+	ctypes.RegisterInterfaces(interfaceRegistry)
 
 	marshaler := codec.NewProtoCodec(interfaceRegistry)
 	encodingConfig := EncodingConfig{


### PR DESCRIPTION
This PR is for
when orchestrator starts up, we initialise cosmos client and use it to fetch sender cosmos account details.
The account retrieval is failing as no registered implementations of type types.AccountI.

- [ ] Register interface implementations of AccountI & EthAccount.