### PR TITLE
Multiple Peggo Fixes

### DIFF
--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -205,7 +205,7 @@ func orchestratorCmd(cmd *cli.Cmd) {
 		)
 		cancelWait()
 
-		ethCommitter, err := committer.NewEthCommitter(ethcmn.Address{}, nil, ethProvider)
+		ethCommitter, err := committer.NewEthCommitter(ethKeyFromAddress, signerFn, ethProvider)
 		orShutdown(err)
 
 		peggyContract, err := peggy.NewPeggyContract(ethCommitter, peggyAddress)

--- a/orchestrator/cosmos/broadcast.go
+++ b/orchestrator/cosmos/broadcast.go
@@ -93,7 +93,6 @@ func (s *peggyBroadcastClient) AccFromAddress() sdk.AccAddress {
 	return s.broadcastClient.FromAddress()
 }
 
-
 type peggyBroadcastClient struct {
 	daemonQueryClient types.QueryClient
 	broadcastClient   client.CosmosClient
@@ -243,7 +242,7 @@ func (s *peggyBroadcastClient) sendDepositClaims(
 		TokenContract:  deposit.TokenContract.Hex(),
 		Amount:         sdk.NewIntFromBigInt(deposit.Amount),
 		EthereumSender: deposit.Sender.Hex(),
-		CosmosReceiver: sdk.AccAddress(deposit.Destination[:]).String(),
+		CosmosReceiver: sdk.AccAddress(deposit.Destination[12:32]).String(),
 		Orchestrator:   s.broadcastClient.FromAddress().String(),
 	}
 

--- a/orchestrator/cosmos/broadcast.go
+++ b/orchestrator/cosmos/broadcast.go
@@ -171,7 +171,7 @@ func (s *peggyBroadcastClient) SendValsetConfirm(
 	// chain store and submit them to Ethereum to update the validator set
 	// -------------
 	msg := &types.MsgValsetConfirm{
-		Orchestrator: s.ValFromAddress().String(),
+		Orchestrator: s.AccFromAddress().String(),
 		EthAddress:   ethFrom.Hex(),
 		Nonce:        valset.Nonce,
 		Signature:    ethcmn.Bytes2Hex(signature),
@@ -212,7 +212,7 @@ func (s *peggyBroadcastClient) SendBatchConfirm(
 	// as well as an Ethereum signature over this batch by the validator
 	// -------------
 	msg := &types.MsgConfirmBatch{
-		Orchestrator:  s.ValFromAddress().String(),
+		Orchestrator:  s.AccFromAddress().String(),
 		Nonce:         batch.BatchNonce,
 		Signature:     ethcmn.Bytes2Hex(signature),
 		EthSigner:     ethFrom.Hex(),
@@ -265,7 +265,7 @@ func (s *peggyBroadcastClient) sendWithdrawClaims(
 		EventNonce:    withdraw.EventNonce.Uint64(),
 		BatchNonce:    withdraw.BatchNonce.Uint64(),
 		TokenContract: withdraw.Token.Hex(),
-		Orchestrator:  s.ValFromAddress().String(),
+		Orchestrator:  s.AccFromAddress().String(),
 	}
 	if err := s.broadcastClient.QueueBroadcastMsg(msg); err != nil {
 		metrics.ReportFuncError(s.svcTags)
@@ -347,7 +347,7 @@ func (s *peggyBroadcastClient) SendToEth(
 	// actually send this message in the first place. So a successful send has
 	// two layers of fees for the user
 	msg := &types.MsgSendToEth{
-		Sender:    s.ValFromAddress().String(),
+		Sender:    s.AccFromAddress().String(),
 		EthDest:   destination.Hex(),
 		Amount:    amount,
 		BridgeFee: fee, // TODO: use exactly that fee for transaction
@@ -380,7 +380,7 @@ func (s *peggyBroadcastClient) SendRequestBatch(
 	// -------------
 	msg := &types.MsgRequestBatch{
 		Denom:        denom,
-		Orchestrator: s.ValFromAddress().String(),
+		Orchestrator: s.AccFromAddress().String(),
 	}
 	if err := s.broadcastClient.QueueBroadcastMsg(msg); err != nil {
 		metrics.ReportFuncError(s.svcTags)

--- a/orchestrator/cosmos/query.go
+++ b/orchestrator/cosmos/query.go
@@ -14,10 +14,10 @@ import (
 type PeggyQueryClient interface {
 	ValsetAt(ctx context.Context, nonce uint64) (*types.Valset, error)
 	CurrentValset(ctx context.Context) (*types.Valset, error)
-	OldestUnsignedValsets(ctx context.Context, valAddress sdk.ValAddress) ([]*types.Valset, error)
+	OldestUnsignedValsets(ctx context.Context, valAccountAddress sdk.AccAddress) ([]*types.Valset, error)
 	LatestValsets(ctx context.Context) ([]*types.Valset, error)
 	AllValsetConfirms(ctx context.Context, nonce uint64) ([]*types.MsgValsetConfirm, error)
-	OldestUnsignedTransactionBatch(ctx context.Context, valAddress sdk.ValAddress) (*types.OutgoingTxBatch, error)
+	OldestUnsignedTransactionBatch(ctx context.Context, valAccountAddress sdk.AccAddress) (*types.OutgoingTxBatch, error)
 	LatestTransactionBatches(ctx context.Context) ([]*types.OutgoingTxBatch, error)
 	UnbatchedTokensWithFees(ctx context.Context) ([]*types.BatchFees, error)
 
@@ -79,13 +79,13 @@ func (s *peggyQueryClient) CurrentValset(ctx context.Context) (*types.Valset, er
 	return daemonResp.Valset, nil
 }
 
-func (s *peggyQueryClient) OldestUnsignedValsets(ctx context.Context, valAddress sdk.ValAddress) ([]*types.Valset, error) {
+func (s *peggyQueryClient) OldestUnsignedValsets(ctx context.Context, valAccountAddress sdk.AccAddress) ([]*types.Valset, error) {
 	metrics.ReportFuncCall(s.svcTags)
 	doneFn := metrics.ReportFuncTiming(s.svcTags)
 	defer doneFn()
 
 	daemonResp, err := s.daemonQueryClient.LastPendingValsetRequestByAddr(ctx, &types.QueryLastPendingValsetRequestByAddrRequest{
-		Address: valAddress.String(),
+		Address: valAccountAddress.String(),
 	})
 	if err != nil {
 		metrics.ReportFuncError(s.svcTags)
@@ -134,13 +134,13 @@ func (s *peggyQueryClient) AllValsetConfirms(ctx context.Context, nonce uint64) 
 	return daemonResp.Confirms, nil
 }
 
-func (s *peggyQueryClient) OldestUnsignedTransactionBatch(ctx context.Context, valAddress sdk.ValAddress) (*types.OutgoingTxBatch, error) {
+func (s *peggyQueryClient) OldestUnsignedTransactionBatch(ctx context.Context, valAccountAddress sdk.AccAddress) (*types.OutgoingTxBatch, error) {
 	metrics.ReportFuncCall(s.svcTags)
 	doneFn := metrics.ReportFuncTiming(s.svcTags)
 	defer doneFn()
 
 	daemonResp, err := s.daemonQueryClient.LastPendingBatchRequestByAddr(ctx, &types.QueryLastPendingBatchRequestByAddrRequest{
-		Address: valAddress.String(),
+		Address: valAccountAddress.String(),
 	})
 	if err != nil {
 		metrics.ReportFuncError(s.svcTags)

--- a/orchestrator/eth_event_watcher.go
+++ b/orchestrator/eth_event_watcher.go
@@ -91,7 +91,7 @@ func (s *peggyOrchestrator) CheckForEvents(
 	if len(deposits) > 0 {
 		log.WithFields(log.Fields{
 			"sender":      deposits[0].Sender.Hex(),
-			"destination": sdk.AccAddress(deposits[0].Destination[:]).String(),
+			"destination": sdk.AccAddress(deposits[0].Destination[12:32]).String(),
 			"amount":      deposits[0].Amount.String(),
 			"event_nonce": deposits[0].EventNonce.String(),
 		}).Infoln("Oracle observed a deposit")

--- a/orchestrator/ethereum/committer/eth_committer.go
+++ b/orchestrator/ethereum/committer/eth_committer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 	"strings"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -97,6 +98,7 @@ func (e *ethCommitter) SendTx(
 		})
 	}
 
+	fmt.Println("venky", "e.FromAddress", e.fromAddress)
 	if err := e.nonceCache.Serialize(e.fromAddress, func() (err error) {
 		nonce := e.nonceCache.Incr(e.fromAddress)
 		var resyncUsed bool

--- a/orchestrator/ethereum/peggy/message_signatures.go
+++ b/orchestrator/ethereum/peggy/message_signatures.go
@@ -94,12 +94,13 @@ func EncodeTxBatchConfirm(peggyID common.Hash, batch *types.OutgoingTxBatch) com
 		txFees,
 		big.NewInt(int64(batch.BatchNonce)),
 		common.HexToAddress(batch.TokenContract),
+		big.NewInt(int64(batch.BatchTimeout)),
 	)
 
 	// this should never happen outside of test since any case that could crash on encoding
 	// should be filtered above.
 	if err != nil {
-		log.WithError(err).Errorln("Error packing checkpoint!")
+		log.WithError(err).Errorln("Error packing transactionBatch!")
 		return common.Hash{}
 
 	}

--- a/orchestrator/ethereum/peggy/submit_batch.go
+++ b/orchestrator/ethereum/peggy/submit_batch.go
@@ -32,6 +32,7 @@ func (s *peggyContract) SendTransactionBatch(
 	amounts, destinations, fees := getBatchCheckpointValues(batch)
 	currentValsetNonce := new(big.Int).SetUint64(currentValset.Nonce)
 	batchNonce := new(big.Int).SetUint64(batch.BatchNonce)
+	batchTimeout := new(big.Int).SetUint64(batch.BatchTimeout)
 
 	// Solidity function signature
 	// function submitBatch(
@@ -62,6 +63,7 @@ func (s *peggyContract) SendTransactionBatch(
 		fees,
 		batchNonce,
 		common.HexToAddress(batch.TokenContract),
+		batchTimeout,
 	)
 	if err != nil {
 		log.WithError(err).Errorln("ABI Pack (Peggy submitBatch) method")

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -179,7 +179,7 @@ func (s *peggyOrchestrator) EthSignerMainLoop(ctx context.Context) (err error) {
 		var oldestUnsignedValsets []*types.Valset
 
 		if err := retry.Do(func() error {
-			oldestValsets, err := s.cosmosQueryClient.OldestUnsignedValsets(ctx, s.peggyBroadcastClient.ValFromAddress())
+			oldestValsets, err := s.cosmosQueryClient.OldestUnsignedValsets(ctx, s.peggyBroadcastClient.AccFromAddress())
 			if err != nil {
 				if err == cosmos.ErrNotFound || oldestValsets == nil {
 					logger.Debugln("no Valset waiting to be signed")
@@ -216,7 +216,7 @@ func (s *peggyOrchestrator) EthSignerMainLoop(ctx context.Context) (err error) {
 		if err := retry.Do(func() error {
 			// sign the last unsigned batch, TODO check if we already have signed this
 
-			txBatch, err := s.cosmosQueryClient.OldestUnsignedTransactionBatch(ctx, s.peggyBroadcastClient.ValFromAddress())
+			txBatch, err := s.cosmosQueryClient.OldestUnsignedTransactionBatch(ctx, s.peggyBroadcastClient.AccFromAddress())
 			if err != nil {
 				if err == cosmos.ErrNotFound || txBatch == nil {
 					logger.Debugln("no TransactionBatch waiting to be signed")


### PR DESCRIPTION
- [x] Get cosmos address from destination bytes. Destination length is 32. Take last 20 bytes to get cosmos address.  
- [x] Use Validator Account address when broadcasting msgs.
- [x] when confirming batch, abi pack is failing as `batchTimeout` is not present.
- [x] nil pointer when relaying batches/valsets.