### PR TITLE
Initiate metric options and add metric hooks

### DIFF
--- a/cmd/peggo/app_metrics.go
+++ b/cmd/peggo/app_metrics.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/InjectiveLabs/peggo/orchestrator/metrics"
+	cli "github.com/jawher/mow.cli"
+	"github.com/xlab/closer"
+	log "github.com/xlab/suplog"
+)
+
+func initMetrics(c *cli.Cmd) {
+	var (
+		statsdPrefix   *string
+		statsdAddr     *string
+		statsdStuckDur *string
+		statsdMocking  *string
+		statsdDisabled *string
+	)
+
+	initStatsdOptions(
+		c,
+		&statsdPrefix,
+		&statsdAddr,
+		&statsdStuckDur,
+		&statsdMocking,
+		&statsdDisabled,
+	)
+
+	if toBool(*statsdDisabled) {
+		// initializes statsd client with a mock one with no-op enabled
+		metrics.Disable()
+	} else {
+		go func() {
+			for {
+				hostname, _ := os.Hostname()
+				err := metrics.Init(*statsdAddr, checkStatsdPrefix(*statsdPrefix), &metrics.StatterConfig{
+					EnvName:              *envName,
+					HostName:             hostname,
+					StuckFunctionTimeout: duration(*statsdStuckDur, 30*time.Minute),
+					MockingEnabled:       toBool(*statsdMocking) || *envName == "local",
+				})
+				if err != nil {
+					log.WithError(err).Warningln("metrics init failed, will retry in 1 min")
+					time.Sleep(time.Minute)
+					continue
+				}
+				break
+			}
+			closer.Bind(func() {
+				metrics.Close()
+			})
+		}()
+	}
+}

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -139,6 +139,10 @@ func orchestratorCmd(cmd *cli.Cmd) {
 		&coingeckoApi,
 	)
 
+	cmd.Before = func() {
+		initMetrics(cmd)
+	}
+
 	cmd.Action = func() {
 		// ensure a clean exit
 		defer closer.Close()

--- a/orchestrator/coingecko/coingecko.go
+++ b/orchestrator/coingecko/coingecko.go
@@ -52,9 +52,13 @@ func urlJoin(baseURL string, segments ...string) string {
 }
 
 func (cp *CoingeckoPriceFeed) QueryUSDPrice(erc20Contract common.Address) (float64, error) {
+	metrics.ReportFuncCall(cp.svcTags)
+	doneFn := metrics.ReportFuncTiming(cp.svcTags)
+	defer doneFn()
 
 	u, err := url.ParseRequestURI(urlJoin(cp.config.BaseURL, "simple", "token_price", "ethereum"))
 	if err != nil {
+		metrics.ReportFuncError(cp.svcTags)
 		cp.logger.WithError(err).Fatalln("failed to parse URL")
 	}
 
@@ -67,11 +71,13 @@ func (cp *CoingeckoPriceFeed) QueryUSDPrice(erc20Contract common.Address) (float
 	reqURL := u.String()
 	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
+		metrics.ReportFuncError(cp.svcTags)
 		cp.logger.WithError(err).Fatalln("failed to create HTTP request")
 	}
 
 	resp, err := cp.client.Do(req)
 	if err != nil {
+		metrics.ReportFuncError(cp.svcTags)
 		err = errors.Wrapf(err, "failed to fetch price from %s", reqURL)
 		return zeroPrice, err
 	}
@@ -79,6 +85,7 @@ func (cp *CoingeckoPriceFeed) QueryUSDPrice(erc20Contract common.Address) (float
 	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 	if err != nil {
 		_ = resp.Body.Close()
+		metrics.ReportFuncError(cp.svcTags)
 		err = errors.Wrapf(err, "failed to read response body from %s", reqURL)
 		return zeroPrice, err
 	}
@@ -132,8 +139,13 @@ func checkCoingeckoConfig(cfg *Config) *Config {
 }
 
 func (cp *CoingeckoPriceFeed) CheckFeeThreshold(erc20Contract common.Address, totalFee cosmtypes.Int, minFeeInUSD float64) bool {
+	metrics.ReportFuncCall(cp.svcTags)
+	doneFn := metrics.ReportFuncTiming(cp.svcTags)
+	defer doneFn()
+
 	tokenPriceInUSD, err := cp.QueryUSDPrice(erc20Contract)
 	if err != nil {
+		metrics.ReportFuncError(cp.svcTags)
 		return false
 	}
 

--- a/orchestrator/cosmos/broadcast.go
+++ b/orchestrator/cosmos/broadcast.go
@@ -243,6 +243,9 @@ func (s *peggyBroadcastClient) sendDepositClaims(
 	// claimed to have seen the deposit enter the ethereum blockchain coins are
 	// issued to the Cosmos address in question
 	// -------------
+	metrics.ReportFuncCall(s.svcTags)
+	doneFn := metrics.ReportFuncTiming(s.svcTags)
+	defer doneFn()
 
 	log.WithFields(log.Fields{
 		"sender":      deposit.Sender.Hex(),
@@ -279,6 +282,9 @@ func (s *peggyBroadcastClient) sendWithdrawClaims(
 	ctx context.Context,
 	withdraw *wrappers.PeggyTransactionBatchExecutedEvent,
 ) error {
+	metrics.ReportFuncCall(s.svcTags)
+	doneFn := metrics.ReportFuncTiming(s.svcTags)
+	defer doneFn()
 
 	log.WithFields(log.Fields{
 		"nonce":          withdraw.BatchNonce.String(),
@@ -314,6 +320,9 @@ func (s *peggyBroadcastClient) sendValsetUpdateClaims(
 	ctx context.Context,
 	valsetUpdate *wrappers.PeggyValsetUpdatedEvent,
 ) error {
+	metrics.ReportFuncCall(s.svcTags)
+	doneFn := metrics.ReportFuncTiming(s.svcTags)
+	defer doneFn()
 
 	log.WithFields(log.Fields{
 		"EventNonce":   valsetUpdate.EventNonce.Uint64(),
@@ -366,6 +375,7 @@ func (s *peggyBroadcastClient) SendEthereumClaims(
 	metrics.ReportFuncCall(s.svcTags)
 	doneFn := metrics.ReportFuncTiming(s.svcTags)
 	defer doneFn()
+
 	totalClaimEvents := len(deposits) + len(withdraws) + len(valsetUpdates)
 	var count, i, j, k int
 
@@ -413,10 +423,6 @@ func (s *peggyBroadcastClient) SendToEth(
 	destination ethcmn.Address,
 	amount, fee sdk.Coin,
 ) error {
-	metrics.ReportFuncCall(s.svcTags)
-	doneFn := metrics.ReportFuncTiming(s.svcTags)
-	defer doneFn()
-
 	// MsgSendToEth
 	// This is the message that a user calls when they want to bridge an asset
 	// it will later be removed when it is included in a batch and successfully
@@ -429,6 +435,10 @@ func (s *peggyBroadcastClient) SendToEth(
 	// the fee paid for the bridge, distinct from the fee paid to the chain to
 	// actually send this message in the first place. So a successful send has
 	// two layers of fees for the user
+	metrics.ReportFuncCall(s.svcTags)
+	doneFn := metrics.ReportFuncTiming(s.svcTags)
+	defer doneFn()
+
 	msg := &types.MsgSendToEth{
 		Sender:    s.AccFromAddress().String(),
 		EthDest:   destination.Hex(),
@@ -448,10 +458,6 @@ func (s *peggyBroadcastClient) SendRequestBatch(
 	ctx context.Context,
 	denom string,
 ) error {
-	metrics.ReportFuncCall(s.svcTags)
-	doneFn := metrics.ReportFuncTiming(s.svcTags)
-	defer doneFn()
-
 	// MsgRequestBatch
 	// this is a message anyone can send that requests a batch of transactions to
 	// send across the bridge be created for whatever block height this message is
@@ -461,6 +467,10 @@ func (s *peggyBroadcastClient) SendRequestBatch(
 	// batch, sign it, submit the signatures with a MsgConfirmBatch before a relayer
 	// can finally submit the batch
 	// -------------
+	metrics.ReportFuncCall(s.svcTags)
+	doneFn := metrics.ReportFuncTiming(s.svcTags)
+	defer doneFn()
+	
 	msg := &types.MsgRequestBatch{
 		Denom:        denom,
 		Orchestrator: s.AccFromAddress().String(),

--- a/orchestrator/cosmos/query.go
+++ b/orchestrator/cosmos/query.go
@@ -30,7 +30,6 @@ type PeggyQueryClient interface {
 func NewPeggyQueryClient(client types.QueryClient) PeggyQueryClient {
 	return &peggyQueryClient{
 		daemonQueryClient: client,
-
 		svcTags: metrics.Tags{
 			"svc": "peggy_query",
 		},
@@ -39,7 +38,6 @@ func NewPeggyQueryClient(client types.QueryClient) PeggyQueryClient {
 
 type peggyQueryClient struct {
 	daemonQueryClient types.QueryClient
-
 	svcTags metrics.Tags
 }
 
@@ -58,6 +56,7 @@ func (s *peggyQueryClient) ValsetAt(ctx context.Context, nonce uint64) (*types.V
 		err = errors.Wrap(err, "failed to query ValsetRequest from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -75,6 +74,7 @@ func (s *peggyQueryClient) CurrentValset(ctx context.Context) (*types.Valset, er
 		err = errors.Wrap(err, "failed to query CurrentValset from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -94,6 +94,7 @@ func (s *peggyQueryClient) OldestUnsignedValsets(ctx context.Context, valAccount
 		err = errors.Wrap(err, "failed to query LastPendingValsetRequestByAddr from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -111,6 +112,7 @@ func (s *peggyQueryClient) LatestValsets(ctx context.Context) ([]*types.Valset, 
 		err = errors.Wrap(err, "failed to query LastValsetRequests from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -130,6 +132,7 @@ func (s *peggyQueryClient) AllValsetConfirms(ctx context.Context, nonce uint64) 
 		err = errors.Wrap(err, "failed to query ValsetConfirmsByNonce from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -149,6 +152,7 @@ func (s *peggyQueryClient) OldestUnsignedTransactionBatch(ctx context.Context, v
 		err = errors.Wrap(err, "failed to query LastPendingBatchRequestByAddr from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -166,6 +170,7 @@ func (s *peggyQueryClient) LatestTransactionBatches(ctx context.Context) ([]*typ
 		err = errors.Wrap(err, "failed to query OutgoingTxBatches from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -183,6 +188,7 @@ func (s *peggyQueryClient) UnbatchedTokensWithFees(ctx context.Context) ([]*type
 		err = errors.Wrap(err, "failed to query BatchFees from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -203,6 +209,7 @@ func (s *peggyQueryClient) TransactionBatchSignatures(ctx context.Context, nonce
 		err = errors.Wrap(err, "failed to query BatchConfirms from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -222,6 +229,7 @@ func (s *peggyQueryClient) LastClaimEventByAddr(ctx context.Context, validatorAc
 		err = errors.Wrap(err, "failed to query LastEventByAddr from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 
@@ -239,6 +247,7 @@ func (s *peggyQueryClient) PeggyParams(ctx context.Context) (*types.Params, erro
 		err = errors.Wrap(err, "failed to query PeggyParams from daemon")
 		return nil, err
 	} else if daemonResp == nil {
+		metrics.ReportFuncError(s.svcTags)
 		return nil, ErrNotFound
 	}
 

--- a/orchestrator/ethereum/committer/eth_committer.go
+++ b/orchestrator/ethereum/committer/eth_committer.go
@@ -93,6 +93,7 @@ func (e *ethCommitter) SendTx(
 	// Figure out the gas price values
 	suggestedGasPrice, err := e.evmProvider.SuggestGasPrice(opts.Context)
 	if err != nil {
+		metrics.ReportFuncError(e.svcTags)
 		return common.Hash{}, errors.Errorf("failed to suggest gas price: %v", err)
 	}
 

--- a/orchestrator/ethereum/peggy/send_to_cosmos.go
+++ b/orchestrator/ethereum/peggy/send_to_cosmos.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/xlab/suplog"
 
+	"github.com/InjectiveLabs/peggo/orchestrator/metrics"
 	wrappers "github.com/InjectiveLabs/peggo/solidity/wrappers/Peggy.sol"
 )
 
@@ -20,8 +21,13 @@ func (s *peggyContract) SendToCosmos(
 	cosmosAccAddress sdk.AccAddress,
 	senderAddress common.Address,
 ) (*common.Hash, error) {
+	metrics.ReportFuncCall(s.svcTags)
+	doneFn := metrics.ReportFuncTiming(s.svcTags)
+	defer doneFn()
+
 	erc20Wrapper, err := wrappers.NewERC20(erc20, s.ethProvider)
 	if err != nil {
+		metrics.ReportFuncError(s.svcTags)
 		err = errors.Wrap(err, "failed to get ERC20 wrapper")
 		return nil, err
 	}
@@ -30,18 +36,21 @@ func (s *peggyContract) SendToCosmos(
 		From:    common.Address{},
 		Context: ctx,
 	}, senderAddress, s.peggyAddress); err != nil {
+		metrics.ReportFuncError(s.svcTags)
 		err = errors.Wrap(err, "failed to get ERC20 allowance for peggy contract")
 		return nil, err
 	} else if allowance.Cmp(maxUintAllowance) != 0 {
 		// allowance not set or not max (a.k.a. unlocked token)
 		txData, err := erc20ABI.Pack("approve", s.peggyAddress, maxUintAllowance)
 		if err != nil {
+			metrics.ReportFuncError(s.svcTags)
 			log.WithError(err).Errorln("ABI Pack (ERC20 approve) method")
 			return nil, err
 		}
 
 		txHash, err := s.SendTx(ctx, erc20, txData)
 		if err != nil {
+			metrics.ReportFuncError(s.svcTags)
 			log.WithError(err).WithField("tx_hash", txHash.Hex()).Errorln("Failed to sign and submit (ERC20 approve) to EVM")
 			return nil, err
 		}
@@ -60,12 +69,14 @@ func (s *peggyContract) SendToCosmos(
 
 	txData, err := peggyABI.Pack("sendToCosmos", erc20, cosmosDestAddressBytes, amount)
 	if err != nil {
+		metrics.ReportFuncError(s.svcTags)
 		log.WithError(err).Errorln("ABI Pack (Peggy sendToCosmos) method")
 		return nil, err
 	}
 
 	txHash, err := s.SendTx(ctx, s.peggyAddress, txData)
 	if err != nil {
+		metrics.ReportFuncError(s.svcTags)
 		log.WithError(err).WithField("tx_hash", txHash.Hex()).Errorln("Failed to sign and submit (Peggy sendToCosmos) to EVM")
 		return nil, err
 	}

--- a/orchestrator/oracle_resync.go
+++ b/orchestrator/oracle_resync.go
@@ -2,12 +2,18 @@ package orchestrator
 
 import (
 	"context"
+	"github.com/InjectiveLabs/peggo/orchestrator/metrics"
 )
 
 // GetLastCheckedBlock retrieves the last claim event this oracle has relayed to Cosmos.
 func (s *peggyOrchestrator) GetLastCheckedBlock(ctx context.Context) (uint64, error) {
+	metrics.ReportFuncCall(s.svcTags)
+	doneFn := metrics.ReportFuncTiming(s.svcTags)
+	defer doneFn()
+
 	lastClaimEvent, err := s.cosmosQueryClient.LastClaimEventByAddr(ctx, s.peggyBroadcastClient.AccFromAddress())
 	if err != nil {
+		metrics.ReportFuncError(s.svcTags)
 		return uint64(0), err
 	}
 


### PR DESCRIPTION
This may have duplicate metric reports on different depth of a call stack as multiple functions within a call stack may have its metrics hook configured.
I think it's good to collect as much as we can for better insight, we can always use grafana influx query to filter the ones we need. Else please delete metrics where you think it's inappropriate.