### PR TITLE
feat: add eventNonce to subgraph withdraw and sendToCosmosEvent mapping

### DIFF
--- a/solidity/subgraph/schema.graphql
+++ b/solidity/subgraph/schema.graphql
@@ -13,6 +13,7 @@ type Deposit @entity {
   sender: Bytes!
   destination: String!
   amount: BigInt!
+  eventNonce: Int!
   timestamp: Int!
   blockHeight: Int!
 }
@@ -36,6 +37,7 @@ type Withdrawal @entity {
   destination: String!
   fee: BigInt!
   tokenContract: Bytes!
+  eventNonce: Int!
   timestamp: Int!
   blockHeight: Int!
 }

--- a/solidity/subgraph/src/mapping.ts
+++ b/solidity/subgraph/src/mapping.ts
@@ -155,6 +155,7 @@ export function handleSendToCosmosEvent(event: SendToCosmosEvent): void {
   deposit.amount = event.params._amount;
   deposit.destination = getInjectiveAddress(event.params._destination);
   deposit.sender = event.params._sender;
+  deposit.eventNonce = event.params._eventNonce.toI32();
   deposit.timestamp = event.block.timestamp.toI32();
   deposit.blockHeight = event.block.number.toI32();
 
@@ -267,6 +268,7 @@ export function handleSubmitBatch(call: SubmitBatchCall): void {
     );
     withdrawal.fee = fees[i];
     withdrawal.tokenContract = call.inputs._tokenContract;
+    withdrawal.eventNonce = call.inputs._batchNonce.toI32();
     withdrawal.timestamp = call.block.timestamp.toI32();
     withdrawal.blockHeight = call.block.number.toI32();
 


### PR DESCRIPTION
## This PR:
- adds eventNonce to subgraph `withdrawal` and `deposit` mapping