### PR TITLE
fix: Fix "nonce too low" error

### DIFF
--- a/orchestrator/ethereum/committer/eth_committer.go
+++ b/orchestrator/ethereum/committer/eth_committer.go
@@ -160,8 +160,8 @@ func (e *ethCommitter) SendTx(
 				err := errors.New("failed to sign transaction")
 				e.nonceCache.Incr(e.fromAddress)
 				return err
-			case strings.Contains(err.Error(), "nonce is too low"),
-				strings.Contains(err.Error(), "nonce is too high"),
+			case strings.Contains(err.Error(), "nonce too low"),
+				strings.Contains(err.Error(), "nonce too high"),
 				strings.Contains(err.Error(), "the tx doesn't have the correct nonce"):
 
 				if resyncUsed {


### PR DESCRIPTION
This is an error we've been having for a long time and I got a good laugh when I found out that the solution was so simple.

Because we weren't checking for the right error, the error was being returned (and retried as is) instead of resyncing the nonce and retrying. This caused that Peggo exited instead of handling it gracefully, like it was coded to do so.

Kudos to @chalermporn17 for identifying the cause of this extremely annoying error!

See:
https://github.com/umee-network/peggo/issues/122
https://github.com/umee-network/peggo/issues/80
PR in Umee's Peggo: https://github.com/umee-network/peggo/pull/128/files#diff-b0a3e8729206d03bb984cb62d1659283cb0628af6a991adf56f0b00f9ad09839L176-R177