### PR TITLE
Add orhcestrator mode for non validator ETH addresses

### DIFF
--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -222,6 +222,20 @@ func orchestratorCmd(cmd *cli.Cmd) {
 
 		//	TODO: (dbrajovic)
 		//	Check if the provided INJ address (valAddress) belongs to a validator
+		ctx, cancelFn = context.WithTimeout(context.Background(), time.Second * 30)
+		defer cancelFn()
+
+		currentValset, err := cosmosQueryClient.CurrentValset(ctx)
+		if err != nil {
+			log.WithError(err).Fatalln("failed to query the current validator set on injective")
+		}
+
+		var isValidator bool
+		for _, validator := range currentValset.Members {
+			if validator.EthereumAddress == ethKeyFromAddress.String() {
+				isValidator = true
+			}
+		}
 
 		erc20ContractMapping := make(map[ethcmn.Address]string)
 		erc20ContractMapping[injAddress] = ctypes.InjectiveCoin

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -220,7 +220,7 @@ func orchestratorCmd(cmd *cli.Cmd) {
 		peggyAddress := ethcmn.HexToAddress(peggyParams.BridgeEthereumAddress)
 		injAddress := ethcmn.HexToAddress(peggyParams.CosmosCoinErc20Contract)
 
-		//	Check if the provided ETH address (valAddress) belongs to a validator
+		// Check if the provided ETH address belongs to a validator
 		ctx, cancelFn = context.WithTimeout(context.Background(), time.Second * 30)
 		defer cancelFn()
 

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -220,6 +220,9 @@ func orchestratorCmd(cmd *cli.Cmd) {
 		peggyAddress := ethcmn.HexToAddress(peggyParams.BridgeEthereumAddress)
 		injAddress := ethcmn.HexToAddress(peggyParams.CosmosCoinErc20Contract)
 
+		//	TODO: (dbrajovic)
+		//	Check if the provided INJ address (valAddress) belongs to a validator
+
 		erc20ContractMapping := make(map[ethcmn.Address]string)
 		erc20ContractMapping[injAddress] = ctypes.InjectiveCoin
 

--- a/cmd/peggo/orchestrator.go
+++ b/cmd/peggo/orchestrator.go
@@ -220,8 +220,7 @@ func orchestratorCmd(cmd *cli.Cmd) {
 		peggyAddress := ethcmn.HexToAddress(peggyParams.BridgeEthereumAddress)
 		injAddress := ethcmn.HexToAddress(peggyParams.CosmosCoinErc20Contract)
 
-		//	TODO: (dbrajovic)
-		//	Check if the provided INJ address (valAddress) belongs to a validator
+		//	Check if the provided ETH address (valAddress) belongs to a validator
 		ctx, cancelFn = context.WithTimeout(context.Background(), time.Second * 30)
 		defer cancelFn()
 
@@ -286,7 +285,7 @@ func orchestratorCmd(cmd *cli.Cmd) {
 		)
 
 		go func() {
-			if err := svc.Start(ctx); err != nil {
+			if err := svc.Start(ctx, isValidator); err != nil {
 				log.Errorln(err)
 
 				// signal there that the app failed

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -26,6 +26,10 @@ const defaultLoopDur = 60 * time.Second
 // Start combines the all major roles required to make
 // up the Orchestrator, all of these are async loops.
 func (s *peggyOrchestrator) Start(ctx context.Context) error {
+	//	TODO: (dbrajovic)
+	//	split into 2 modes (validator, non-validator)
+	//	non-validator runs only BatchRequesterLoop and RelayerMainLoop
+
 	var pg loops.ParanoidGroup
 
 	pg.Go(func() error {

--- a/orchestrator/main_loops.go
+++ b/orchestrator/main_loops.go
@@ -25,27 +25,12 @@ const defaultLoopDur = 60 * time.Second
 
 // Start combines the all major roles required to make
 // up the Orchestrator, all of these are async loops.
-func (s *peggyOrchestrator) Start(ctx context.Context) error {
-	//	TODO: (dbrajovic)
-	//	split into 2 modes (validator, non-validator)
-	//	non-validator runs only BatchRequesterLoop and RelayerMainLoop
+func (s *peggyOrchestrator) Start(ctx context.Context, validatorMode bool) error {
+	if !validatorMode {
+		return s.startRelayerMode(ctx)
+	}
 
-	var pg loops.ParanoidGroup
-
-	pg.Go(func() error {
-		return s.EthOracleMainLoop(ctx)
-	})
-	pg.Go(func() error {
-		return s.BatchRequesterLoop(ctx)
-	})
-	pg.Go(func() error {
-		return s.EthSignerMainLoop(ctx)
-	})
-	pg.Go(func() error {
-		return s.RelayerMainLoop(ctx)
-	})
-
-	return pg.Wait()
+	return s.startValidatorMode(ctx)
 }
 
 // EthOracleMainLoop is responsible for making sure that Ethereum events are retrieved from the Ethereum blockchain
@@ -398,4 +383,42 @@ func calculateTotalValsetPower(valset *types.Valset) *big.Int {
 	}
 
 	return totalValsetPower
+}
+
+//	startValidatorMode runs all orchestrator processes. This is called
+//	when peggo is run alongside a validator injective node.
+func (s *peggyOrchestrator) startValidatorMode(ctx context.Context) error {
+	var pg loops.ParanoidGroup
+
+	pg.Go(func() error {
+		return s.EthOracleMainLoop(ctx)
+	})
+	pg.Go(func() error {
+		return s.BatchRequesterLoop(ctx)
+	})
+	pg.Go(func() error {
+		return s.EthSignerMainLoop(ctx)
+	})
+	pg.Go(func() error {
+		return s.RelayerMainLoop(ctx)
+	})
+
+	return pg.Wait()
+}
+
+//	startRelayerMode runs orchestrator processes that only relay specific
+//	messages that do not require a validator's signature. This mode is run
+//	alongside a non-validator injective node
+func (s *peggyOrchestrator) startRelayerMode(ctx context.Context) error {
+	var pg loops.ParanoidGroup
+
+	pg.Go(func() error {
+		return s.BatchRequesterLoop(ctx)
+	})
+
+	pg.Go(func() error {
+		return s.RelayerMainLoop(ctx)
+	})
+
+	return pg.Wait()
 }

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -17,7 +17,7 @@ import (
 )
 
 type PeggyOrchestrator interface {
-	Start(ctx context.Context) error
+	Start(ctx context.Context, validatorMode bool) error
 
 	CheckForEvents(ctx context.Context, startingBlock uint64) (currentBlock uint64, err error)
 	GetLastCheckedBlock(ctx context.Context) (uint64, error)


### PR DESCRIPTION
This PR adds a check to determine if the provided ETH address belongs to a validator on the injective network. Essentially, there are 2 modes: 

1. Validator mode (existing behavior): run `peggo` alongside an injective validator node
2. Relayer mode (new): run `peggo` alongside an injective non-validator mode to relay specific messages that do not require Validator signing (checkpoints updates, valset updates, batch requests)

In any case, the check queries the injective client for the active valset to determine in which mode to run `peggo`. 