### PR TITLE
Fix estimate gas

### DIFF
--- a/orchestrator/ethereum/committer/eth_committer.go
+++ b/orchestrator/ethereum/committer/eth_committer.go
@@ -2,6 +2,7 @@ package committer
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum"
 	"math/big"
 	"strings"
 
@@ -113,6 +114,34 @@ func (e *ethCommitter) SendTx(
 	if opts.GasPrice.Cmp(maxGasPrice) > 0 {
 		return common.Hash{}, errors.Errorf("Suggested gas price %v is greater than max gas price %v", opts.GasPrice.Int64(), maxGasPrice.Int64())
 	}
+
+	// estimate gas limit
+	peggyContract := recipient
+
+	// Gas estimation cannot succeed without code for method invocations
+	code, err := e.evmProvider.PendingCodeAt(opts.Context, peggyContract)
+	if err != nil {
+		return common.Hash{}, errors.Wrap(err, "failed to get code")
+	}
+
+	if len(code) == 0 {
+		return common.Hash{}, bind.ErrNoCode
+	}
+
+	msg := ethereum.CallMsg{
+		From:     opts.From,
+		To:       &peggyContract,
+		GasPrice: gasPrice,
+		Value:    new(big.Int),
+		Data:     txData,
+	}
+
+	gasLimit, err := e.evmProvider.EstimateGas(opts.Context, msg)
+	if err != nil {
+		return common.Hash{}, errors.Wrap(err, "failed to estimate gas")
+	}
+
+	opts.GasLimit = gasLimit
 
 	resyncNonces := func(from common.Address) {
 		e.nonceCache.Sync(from, func() (uint64, error) {

--- a/orchestrator/ethereum/peggy/submit_batch.go
+++ b/orchestrator/ethereum/peggy/submit_batch.go
@@ -25,9 +25,9 @@ func (s *peggyContract) SendTransactionBatch(
 	log.WithFields(log.Fields{
 		"token_contract": batch.TokenContract,
 		"batch_nonce":    batch.BatchNonce,
-		"transactions":   len(batch.Transactions),
+		"txs":            len(batch.Transactions),
 		"confirmations":  len(confirms),
-	}).Debugln("checking signatures and submitting batch")
+	}).Infoln("checking signatures and submitting batch")
 
 	validators, powers, sigV, sigR, sigS, err := checkBatchSigsAndRepack(currentValset, confirms)
 	if err != nil {

--- a/orchestrator/ethereum/peggy/valset_update.go
+++ b/orchestrator/ethereum/peggy/valset_update.go
@@ -41,7 +41,7 @@ func (s *peggyContract) SendEthValsetUpdate(
 		"valset_nonce":  newValset.Nonce,
 		"validators":    len(newValset.Members),
 		"confirmations": len(confirms),
-	}).Debugln("checking signatures and submitting valset update")
+	}).Infoln("checking signatures and submitting valset update")
 
 	newValidators, newPowers := validatorsAndPowers(newValset)
 	newValsetNonce := new(big.Int).SetUint64(newValset.Nonce)

--- a/orchestrator/relayer.go
+++ b/orchestrator/relayer.go
@@ -125,6 +125,7 @@ func (l *relayerLoop) relayValset(ctx context.Context) error {
 	}
 
 	if oldestConfirmedValset.Nonce <= currentEthValset.Nonce {
+		l.Logger().WithFields(log.Fields{"eth_valset_nonce": currentEthValset.Nonce, "inj_valset_nonce": currentEthValset.Nonce}).Debugln("valset already updated on Ethereum")
 		return nil
 	}
 
@@ -135,6 +136,7 @@ func (l *relayerLoop) relayValset(ctx context.Context) error {
 
 	// Check if other validators already updated the valset
 	if oldestConfirmedValset.Nonce <= latestEthereumValsetNonce.Uint64() {
+		l.Logger().WithFields(log.Fields{"eth_valset_nonce": latestEthereumValsetNonce, "inj_valset_nonce": currentEthValset.Nonce}).Debugln("valset already updated on Ethereum")
 		return nil
 	}
 
@@ -212,6 +214,7 @@ func (l *relayerLoop) relayBatch(ctx context.Context) error {
 	}
 
 	if oldestConfirmedBatch.BatchNonce <= latestEthereumBatch.Uint64() {
+		l.Logger().WithFields(log.Fields{"eth_batch_nonce": latestEthereumBatch.Uint64(), "inj_batch_nonce": oldestConfirmedBatch.BatchNonce}).Debugln("batch already updated on Ethereum")
 		return nil
 	}
 
@@ -222,6 +225,7 @@ func (l *relayerLoop) relayBatch(ctx context.Context) error {
 
 	// Check if ethereum batch was updated by other validators
 	if oldestConfirmedBatch.BatchNonce <= latestEthereumBatch.Uint64() {
+		l.Logger().WithFields(log.Fields{"eth_batch_nonce": latestEthereumBatch.Uint64(), "inj_batch_nonce": oldestConfirmedBatch.BatchNonce}).Debugln("batch already updated on Ethereum")
 		return nil
 	}
 


### PR DESCRIPTION
This PR introduces proper gas limit estimation when relaying batches (valsets). 

Otherwise the accounted for tx hits an `out of gas` error when trying to update the contract. Subsequently, batches get stuck and eventually get timed out. 