### PR TITLE
feat: add balance check for transferring to Injective

### DIFF
--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -146,11 +146,9 @@ contract Peggy is
         );
     }
 
-    function lastBatchNonce(address _erc20Address)
-        public
-        view
-        returns (uint256)
-    {
+    function lastBatchNonce(
+        address _erc20Address
+    ) public view returns (uint256) {
         return state_lastBatchNonces[_erc20Address];
     }
 
@@ -176,11 +174,10 @@ contract Peggy is
     // Where h is the keccak256 hash function.
     // The validator powers must be decreasing or equal. This is important for checking the signatures on the
     // next valset, since it allows the caller to stop verifying signatures once a quorum of signatures have been verified.
-    function makeCheckpoint(ValsetArgs memory _valsetArgs, bytes32 _peggyId)
-        private
-        pure
-        returns (bytes32)
-    {
+    function makeCheckpoint(
+        ValsetArgs memory _valsetArgs,
+        bytes32 _peggyId
+    ) private pure returns (bytes32) {
         // bytes32 encoding of the string "checkpoint"
         bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
@@ -457,17 +454,27 @@ contract Peggy is
         uint256 _amount,
         string calldata _data
     ) external whenNotPaused nonReentrant {
+        uint256 balanceBeforeTransfer = IERC20(_tokenContract).balanceOf(
+            address(this)
+        );
+
         IERC20(_tokenContract).safeTransferFrom(
             msg.sender,
             address(this),
             _amount
         );
+
+        uint256 balanceAfterTransfer = IERC20(_tokenContract).balanceOf(
+            address(this)
+        );
+        uint256 transferAmount = balanceAfterTransfer - balanceBeforeTransfer;
+
         state_lastEventNonce = state_lastEventNonce + 1;
         emit SendToInjectiveEvent(
             _tokenContract,
             msg.sender,
             _destination,
-            _amount,
+            transferAmount,
             state_lastEventNonce,
             _data
         );


### PR DESCRIPTION
* adds support for tokens with fee on transfer

# Copilot Summary

This pull request primarily focuses on the `Peggy` contract in the `solidity/contracts/Peggy.sol` file. The changes include reformatting of function declarations to improve readability and an important modification in the `SendToInjectiveEvent` method to ensure the correct transfer amount is emitted in the event.

Reformatting of function declarations:

* [`solidity/contracts/Peggy.sol`](diffhunk://#diff-d4aa0d16c055fc8c8abc440a485d3c7d433e76f7829599673121f0d64cc4990fL149-R151): Reformatted the `lastBatchNonce` function declaration to improve readability. The function parameters and return type are now on separate lines.
* [`solidity/contracts/Peggy.sol`](diffhunk://#diff-d4aa0d16c055fc8c8abc440a485d3c7d433e76f7829599673121f0d64cc4990fL179-R180): Similarly, the `makeCheckpoint` function declaration has been reformatted for better readability. The function parameters and return type are now on separate lines.

Modification in `SendToInjectiveEvent` method:

* [`solidity/contracts/Peggy.sol`](diffhunk://#diff-d4aa0d16c055fc8c8abc440a485d3c7d433e76f7829599673121f0d64cc4990fR457-R477): In the `SendToInjectiveEvent` method, additional code has been added to calculate the actual transfer amount by checking the balance before and after the transfer. This ensures the correct transfer amount is emitted in the event, instead of the requested amount.