### PR TITLE
feat: add adhoc minting for native tokens on Injective CHAIN-71

### DIFF
--- a/solidity/contracts/@openzeppelin/contracts/Ownable.sol
+++ b/solidity/contracts/@openzeppelin/contracts/Ownable.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "./utils/Context.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor() {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() external virtual onlyOwner {
+        _renounceOwnership();
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) external virtual onlyOwner {
+        require(
+            newOwner != address(0),
+            "Ownable: new owner is the zero address"
+        );
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+
+    function _renounceOwnership() private {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+}

--- a/solidity/contracts/CosmosToken.sol
+++ b/solidity/contracts/CosmosToken.sol
@@ -3,22 +3,31 @@
 pragma solidity ^0.8.0;
 
 import "./@openzeppelin/contracts/ERC20.sol";
+import "./@openzeppelin/contracts/Ownable.sol";
 
-contract CosmosERC20 is ERC20 {
-	uint256 MAX_UINT = 2**256 - 1;
-	uint8 immutable private _decimals;
+contract CosmosERC20 is ERC20, Ownable {
+    uint256 MAX_UINT = 2 ** 256 - 1;
+    uint8 private immutable _decimals;
 
-	constructor(
-		address peggyAddress_,
-		string memory name_,
-		string memory symbol_,
-		uint8 decimals_
-	) ERC20(name_, symbol_) {
-		_decimals = decimals_;
-		_mint(peggyAddress_, MAX_UINT);
-	}
+    constructor(
+        address peggyAddress_,
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+        _mint(peggyAddress_, MAX_UINT);
+    }
 
-	function decimals() public view virtual override returns (uint8) {
-		return _decimals;
-	}
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address account, uint256 amount) public onlyOwner {
+        _mint(account, amount);
+    }
+
+    function burn(address account, uint256 amount) public onlyOwner {
+        _burn(account, amount);
+    }
 }

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -51,6 +51,8 @@ contract Peggy is
     bytes32 public state_peggyId;
     uint256 public state_powerThreshold;
 
+    mapping(address => bool) public isInjectiveNativeToken;
+
     // TransactionBatchExecutedEvent and SendToInjectiveEvent both include the field _eventNonce.
     // This is incremented every time one of these events is emitted. It is checked by the
     // Cosmos module to ensure that all events are received in order, and that none are lost.
@@ -423,10 +425,18 @@ contract Peggy is
                 // Send transaction amounts to destinations
                 uint256 totalFee;
                 for (uint256 i = 0; i < _amounts.length; i++) {
-                    IERC20(_tokenContract).safeTransfer(
-                        _destinations[i],
-                        _amounts[i]
-                    );
+                    if (isInjectiveNativeToken[_tokenContract]) {
+                        CosmosERC20(_tokenContract).mint(
+                            _destinations[i],
+                            _amounts[i]
+                        );
+                    } else {
+                        IERC20(_tokenContract).safeTransfer(
+                            _destinations[i],
+                            _amounts[i]
+                        );
+                    }
+
                     totalFee = totalFee + _fees[i];
                 }
 
@@ -454,22 +464,31 @@ contract Peggy is
         uint256 _amount,
         string calldata _data
     ) external whenNotPaused nonReentrant {
-        uint256 balanceBeforeTransfer = IERC20(_tokenContract).balanceOf(
-            address(this)
-        );
+        uint256 transferAmount;
 
-        IERC20(_tokenContract).safeTransferFrom(
-            msg.sender,
-            address(this),
-            _amount
-        );
+        if (isInjectiveNativeToken[_tokenContract]) {
+            CosmosERC20(_tokenContract).burn(msg.sender, _amount);
 
-        uint256 balanceAfterTransfer = IERC20(_tokenContract).balanceOf(
-            address(this)
-        );
-        uint256 transferAmount = balanceAfterTransfer - balanceBeforeTransfer;
+            transferAmount = _amount;
+        } else {
+            uint256 balanceBeforeTransfer = IERC20(_tokenContract).balanceOf(
+                address(this)
+            );
+
+            IERC20(_tokenContract).safeTransferFrom(
+                msg.sender,
+                address(this),
+                _amount
+            );
+
+            uint256 balanceAfterTransfer = IERC20(_tokenContract).balanceOf(
+                address(this)
+            );
+            transferAmount = balanceAfterTransfer - balanceBeforeTransfer;
+        }
 
         state_lastEventNonce = state_lastEventNonce + 1;
+
         emit SendToInjectiveEvent(
             _tokenContract,
             msg.sender,
@@ -493,6 +512,8 @@ contract Peggy is
             _symbol,
             _decimals
         );
+
+        isInjectiveNativeToken[address(erc20)] = true;
 
         // Fire an event to let the Cosmos module know
         state_lastEventNonce = state_lastEventNonce + 1;

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -505,7 +505,6 @@ contract Peggy is
         string calldata _symbol,
         uint8 _decimals
     ) external {
-        // Deploy an ERC20 with entire supply granted to Peggy.sol
         CosmosERC20 erc20 = new CosmosERC20(
             address(this),
             _name,


### PR DESCRIPTION
- We don't want to mint infinite amounts upon token creation, because it's a bad look. Instead we should mint/burn adhoc.
- More Context [here](https://injectivelabsinc.slack.com/archives/C022J7KTD25/p1712604230397059?thread_ts=1711996711.930519&cid=C022J7KTD25)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `Ownable` contract for access control, enabling owner-restricted functions.
  - Added minting and burning functionalities in the `CosmosERC20` contract, accessible only by the owner.
  - Implemented tracking for specific tokens in the `Peggy` contract with the `isInjectiveNativeToken` mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->