### PR TITLE
fix: remove infinite mint

### DIFF
--- a/solidity/contracts/CosmosToken.sol
+++ b/solidity/contracts/CosmosToken.sol
@@ -6,17 +6,14 @@ import "./@openzeppelin/contracts/ERC20.sol";
 import "./@openzeppelin/contracts/Ownable.sol";
 
 contract CosmosERC20 is ERC20, Ownable {
-    uint256 MAX_UINT = 2 ** 256 - 1;
     uint8 private immutable _decimals;
 
     constructor(
-        address peggyAddress_,
         string memory name_,
         string memory symbol_,
         uint8 decimals_
     ) ERC20(name_, symbol_) {
         _decimals = decimals_;
-        _mint(peggyAddress_, MAX_UINT);
     }
 
     function decimals() public view virtual override returns (uint8) {

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -505,13 +505,7 @@ contract Peggy is
         string calldata _symbol,
         uint8 _decimals
     ) external {
-        CosmosERC20 erc20 = new CosmosERC20(
-            address(this),
-            _name,
-            _symbol,
-            _decimals
-        );
-
+        CosmosERC20 erc20 = new CosmosERC20(_name, _symbol, _decimals);
         isInjectiveNativeToken[address(erc20)] = true;
 
         // Fire an event to let the Cosmos module know


### PR DESCRIPTION
* we are adhoc minting and burning now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the `CosmosToken` contract by removing unused constants and constructor parameters.
	- Updated the `Peggy` contract to streamline the instantiation of the `CosmosERC20` contract, passing only essential parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->